### PR TITLE
Decode bytes object before iterating

### DIFF
--- a/pefile.py
+++ b/pefile.py
@@ -1439,7 +1439,14 @@ def is_valid_dos_filename(s):
         return False
     # Allow path separators as import names can contain directories.
     allowed = allowed_filename + b'\\/'
-    for c in set(s):
+    if isinstance(s, (bytes, bytearray)):
+        try:
+            _s = s.decode(sys.getdefaultencoding())
+        except UnicodeDecodeError:
+            return False
+    else:
+        _s = s
+    for c in set(_s):
         if c not in allowed:
             return False
     return True
@@ -1461,7 +1468,14 @@ else:
 def is_valid_function_name(s):
     if s is None or not isinstance(s, (str, bytes, bytearray)):
         return False
-    for c in set(s):
+    if isinstance(s, (bytes, bytearray)):
+        try:
+            _s = s.decode(sys.getdefaultencoding())
+        except UnicodeDecodeError:
+            return False
+    else:
+        _s = s
+    for c in set(_s):
         if c not in allowed_function_name:
             return False
     return True


### PR DESCRIPTION
Iterating over a bytes or bytearray object returns integers representing Unicode characters, so those should be decoded to strings first to get the expected behavior.